### PR TITLE
A point is 1/72 of an inch, not 1/72.27

### DIFF
--- a/RdlEngine/Definition/RSize.cs
+++ b/RdlEngine/Definition/RSize.cs
@@ -37,7 +37,7 @@ namespace Majorsilence.Reporting.Rdl
 			// in -> inches (1 inch = 2.54 cm)
 			// cm -> centimeters (.01 meters)
 			// mm -> millimeters (.001 meters)
-			// pt -> points (1 point = 1/72.27 inches)
+			// pt -> points (1 point = 1/72 inches)
 			// pc -> Picas (1 pica = 12 points)
 			if (t == null)		// e.g. an expression that evaluated to no result
 			{
@@ -158,8 +158,17 @@ namespace Majorsilence.Reporting.Rdl
 			}
 		}
 
-		static internal readonly float POINTSIZED = 72.27f;
-		static internal readonly decimal POINTSIZEM = 72.27m;
+		// 72 points to the inch. This was 72.27 - TeX's printer's point - for as long as
+		// this engine has existed, and it is the wrong point for everything this engine
+		// talks to: RDL sizes are CSS length units and CSS defines 1pt = 1/72in, PDF user
+		// space is 1/72in, and GDI fonts are 1/72in. With 72.27 every dimension written in
+		// inches came out 0.375% oversized in the PDF - a Letter page had a MediaBox of
+		// 794x614 instead of 612x792, and a 0.215in table row rendered 15.535pt tall
+		// instead of 15.48 - an error that compounds down a page of rows. Sizes given in
+		// pt round-trip through _Size unchanged under either constant, so font sizes do
+		// not move; only in/cm/mm dimensions do, by that 0.375%.
+		static internal readonly float POINTSIZED = 72f;
+		static internal readonly decimal POINTSIZEM = 72m;
 
 		static internal int PixelsFromPoints(float x)
 		{

--- a/RdlEngine/RdlPrint.cs
+++ b/RdlEngine/RdlPrint.cs
@@ -354,7 +354,7 @@ namespace fyiReporting.RDLPrint
         //    return;
         //}
 
-        private float POINTSIZEF = 72.27f;
+        private float POINTSIZEF = 72f;   // see RSize.POINTSIZED - 1pt = 1/72in
 
         private Report GetReport()
         {

--- a/RdlEngine/Utility/Measurement.cs
+++ b/RdlEngine/Utility/Measurement.cs
@@ -79,11 +79,11 @@ namespace Majorsilence.Reporting.Rdl.Utility
         /// <summary>
         /// The constant value used to calculate the conversion of pixels into points, as a float.
         /// </summary>
-        public const float POINTSIZE_F = 72.27f;
+        public const float POINTSIZE_F = 72f;
         /// <summary>
         /// The constant value used to calculate the conversion of pixels into points, as a decimal.
         /// </summary>
-        public const decimal POINTSIZE_M = 72.27m;
+        public const decimal POINTSIZE_M = 72m;
 
         public const float STANDARD_DPI_X = 96f;
         public const float STANDARD_DPI_Y = 96f;

--- a/ReportTests/PageSizeTests.cs
+++ b/ReportTests/PageSizeTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Majorsilence.Reporting.Rdl;
+using NUnit.Framework;
+using ReportTests.Utils;
+using UglyToad.PdfPig;
+
+namespace ReportTests
+{
+    [TestFixture]
+    public class PageSizeTests
+    {
+        private Uri _reportFolder;
+        private Uri _outputFolder;
+
+        [SetUp]
+        public void Prepare()
+        {
+            _outputFolder = GeneralUtils.OutputTestsFolder();
+            _reportFolder = GeneralUtils.ReportsFolder();
+            Directory.CreateDirectory(_outputFolder.LocalPath);
+        }
+
+        /// <summary>
+        /// A PageHeight of 11in must come out as 792 PDF points, because a PDF point is
+        /// 1/72 of an inch - as is a CSS point, which is what RDL sizes are, and a GDI
+        /// point. Inches used to be converted with 72.27 - TeX's printer's point - so every
+        /// dimension written in inches rendered 0.375% oversized: a Letter page had a
+        /// MediaBox of 794x614 instead of 612x792, and a 0.215in table row rendered
+        /// 15.535pt tall instead of 15.48. On a page of rows that error is a pitch, so it
+        /// compounds - by the thirtieth row the table was half a row adrift of where the
+        /// same RDL renders under a correct point.
+        /// </summary>
+        [Test]
+        public async Task LetterPage_IsExactly612By792Points()
+        {
+            var rdl = new Uri(_reportFolder, "ImageSizing.rdl");
+            Report report = await RdlUtils.GetReport(rdl);
+            report.Folder = _reportFolder.LocalPath;
+            await report.RunGetData(null);
+
+            string output = Path.Combine(_outputFolder.LocalPath, "PageSize.pdf");
+            using (var sg = new OneFileStreamGen(output, true))
+            {
+                await report.RunRender(sg, OutputPresentationType.PDF);
+            }
+
+            using var pdf = PdfDocument.Open(output);
+            var page = pdf.GetPages().First();
+            Assert.Multiple(() =>
+            {
+                // The report declares 8.5in x 11in. Within half a point, not exact, only
+                // because the writer rounds to whole points.
+                Assert.That(page.Width, Is.EqualTo(612d).Within(0.5d), "8.5in in points");
+                Assert.That(page.Height, Is.EqualTo(792d).Within(0.5d), "11in in points");
+            });
+        }
+    }
+}


### PR DESCRIPTION
RSize converted inches, centimeters and millimeters to points with 72.27 to the inch - TeX's printer's point. Everything this engine talks to defines the point as 1/72in: PDF user space, CSS lengths (which is what RDL sizes are), and GDI fonts. So every dimension written in inches came out 0.375% oversized in the output: a Letter page had a MediaBox of 794x614 instead of 612x792, and a 0.215in table row rendered 15.535pt tall instead of 15.48. On a page of rows that error is a pitch, so it compounds - a 29-row table ended half a row adrift of where the same RDL renders under a correct point.

Changed in RSize.POINTSIZED/POINTSIZEM, Measurement.POINTSIZE_F/M, and RdlPrint's private copy. Sizes given in pt round-trip through RSize's normalized form unchanged under either constant, so font sizes do not move; only in/cm/mm dimensions do, by that 0.375%. The standalone tools - designer, viewer, reader, RdlCmd, the EAN-13 barcode - carry their own copies of 72.27 and are deliberately left for a separate pass: they draw to screens rather than PDFs and were not verified in this round.

A new test renders a Letter report and asserts the page is 612x792 within the writer's whole-point rounding; with the old constant it fails at 614x794.

ReportTests 261+293+293 across net48/net8/net10, Majorsilence.Pdf.Tests 279 on both targets, RdlCreator.Tests 24 on both, Tests 2 on both - all green.